### PR TITLE
#79 fix

### DIFF
--- a/app/src/main/graphql/edu.ycp.cs482.iorc/queryFile.graphql
+++ b/app/src/main/graphql/edu.ycp.cs482.iorc/queryFile.graphql
@@ -112,6 +112,7 @@ fragment VersionSheetData on Version{
       key
       name
       description
+      skill
       modifiers{
         key
         value


### PR DESCRIPTION
query already existed and was in use since stat calculation began (commit 985d2f6). added a field to the fragment that was left out (skill)