### PR TITLE
Edit fab clipping fixed

### DIFF
--- a/app/src/main/res/layout/activity_character_detail.xml
+++ b/app/src/main/res/layout/activity_character_detail.xml
@@ -73,10 +73,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/fab_margin"
-        android:layout_gravity="bottom|end"
+        android:layout_gravity="center_horizontal|end"
         android:clickable="true"
-        app:layout_anchor="@+id/character_detail_container"
-        app:layout_anchorGravity="bottom|right"
+        app:layout_anchor="@+id/character_bottom"
+        app:layout_anchorGravity="end"
         app:srcCompat="@drawable/ic_edit_black_24dp"
         android:tint="@android:color/white"
         tools:layout_editor_absoluteX="344dp" />


### PR DESCRIPTION
The edit fab button in characterDetail no longer clips into the bottom navigation bar when the layout switches between landscape and portrait.